### PR TITLE
OZ-689: Update distribution management to publish to public Mekom Nexus repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+.idea/.gitignore
+.idea
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+### JEnv ###
+.jenvrc
+.java-version

--- a/pom.xml
+++ b/pom.xml
@@ -176,14 +176,14 @@
 
     <distributionManagement>
         <repository>
-            <id>mks-nexus-private-releases</id>
-            <name>Mekom Solutions Nexus repo</name>
-            <url>https://nexus.mekomsolutions.net/repository/maven-private-releases</url>
+            <id>mks-nexus-public-releases</id>
+            <name>Mekom Solutions Nexus repo for releases</name>
+            <url>https://nexus.mekomsolutions.net/repository/maven-releases</url>
         </repository>
         <snapshotRepository>
-            <id>mks-nexus-private-snapshots</id>
+            <id>mks-nexus-public-snapshots</id>
             <name>Mekom Solutions Nexus repo for snapshots</name>
-            <url>https://nexus.mekomsolutions.net/repository/maven-private-snapshots</url>
+            <url>https://nexus.mekomsolutions.net/repository/maven-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
This PR updates distribution management to publish to public Mekom Nexus repository and adds `.gitignore` file.